### PR TITLE
fix(auth): enable cookie passthrough and align cookie deletion options

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -15,7 +15,7 @@ async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   app.enableCors({
     origin: [
-      "https://taskcraft.click",
+      'https://taskcraft.click',
       'https://localhost:3000',
       'http://localhost:3000',
       'http://localhost:4200',

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -75,7 +75,10 @@ export class AuthController {
   @ApiResponseUnauthorizedDecorator()
   @ApiResponseNotFoundDecorator('User not found')
   @ApiResponseInternalServerErrorDecorator()
-  async login(@Body() loginDto: LoginDto, @Res() res: Response) {
+  async login(
+    @Body() loginDto: LoginDto,
+    @Res({ passthrough: true }) res: Response,
+  ) {
     try {
       return await this.authService.login(
         loginDto.email,
@@ -118,6 +121,15 @@ export class AuthController {
         secure: true, // Убедитесь, что это будет работать только с HTTPS
         sameSite: 'none', // Обеспечивает работу с куки при кросс-доменных запросах
         domain: 'taskcraft.click',
+        path: '/',
+        expires: new Date(0),
+      });
+      res.clearCookie('refresh_token', {
+        httpOnly: true,
+        secure: true,
+        sameSite: 'none',
+        domain: 'taskcraft.click',
+        path: '/',
       });
 
       // Отправляем успешный ответ на логаут


### PR DESCRIPTION
Added { passthrough: true } to @Res() in the login method to allow NestJS to manage cookies without taking over the full response.

Updated res.clearCookie options in the logout method to exactly match the ones used when setting the refresh_token cookie.

Ensures proper removal of the refresh_token cookie in the browser, especially in the production environment on the taskcraft.click domain.

Fixes an issue where the cookie was not being deleted due to mismatched options.